### PR TITLE
feat: Implement IServiceProviderIsService

### DIFF
--- a/Inject.NET.Tests/ServiceProviderIsServiceTests.cs
+++ b/Inject.NET.Tests/ServiceProviderIsServiceTests.cs
@@ -1,0 +1,130 @@
+using Inject.NET.Attributes;
+using Inject.NET.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Inject.NET.Tests;
+
+public partial class ServiceProviderIsServiceTests
+{
+    [Test]
+    public async Task IsService_ReturnsTrueForRegisteredSingleton()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(SingletonService))).IsTrue();
+    }
+
+    [Test]
+    public async Task IsService_ReturnsTrueForRegisteredScoped()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(ScopedService))).IsTrue();
+    }
+
+    [Test]
+    public async Task IsService_ReturnsTrueForRegisteredTransient()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(TransientService))).IsTrue();
+    }
+
+    [Test]
+    public async Task IsService_ReturnsTrueForRegisteredInterface()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(IMyService))).IsTrue();
+    }
+
+    [Test]
+    public async Task IsService_ReturnsFalseForUnregisteredType()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(UnregisteredService))).IsFalse();
+    }
+
+    [Test]
+    public async Task IsService_ReturnsTrueForIServiceProviderIsService()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(IServiceProviderIsService))).IsTrue();
+    }
+
+    [Test]
+    public async Task IsService_ReturnsTrueForIServiceProvider()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(System.IServiceProvider))).IsTrue();
+    }
+
+    [Test]
+    public async Task IsService_CanBeResolvedFromScope()
+    {
+        await using var serviceProvider = await IsServiceTestProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var checker = scope.GetRequiredService<IServiceProviderIsService>();
+
+        await Assert.That(checker).IsNotNull();
+        await Assert.That(checker.IsService(typeof(SingletonService))).IsTrue();
+        await Assert.That(checker.IsService(typeof(UnregisteredService))).IsFalse();
+    }
+
+    [Test]
+    public async Task IsService_ReturnsTrueForOpenGenericRegistration()
+    {
+        await using var serviceProvider = await IsServiceWithGenericsTestProvider.BuildAsync();
+
+        var checker = (IServiceProviderIsService)serviceProvider;
+
+        await Assert.That(checker.IsService(typeof(IGenericService<string>))).IsTrue();
+        await Assert.That(checker.IsService(typeof(IGenericService<int>))).IsTrue();
+    }
+
+    public interface IMyService;
+
+    public class MyServiceImpl : IMyService;
+
+    public class SingletonService;
+
+    public class ScopedService;
+
+    public class TransientService;
+
+    public class UnregisteredService;
+
+    public interface IGenericService<T>;
+
+    public class GenericService<T> : IGenericService<T>;
+
+    [ServiceProvider]
+    [Singleton<SingletonService>]
+    [Scoped<ScopedService>]
+    [Transient<TransientService>]
+    [Singleton<IMyService, MyServiceImpl>]
+    public partial class IsServiceTestProvider;
+
+    [ServiceProvider]
+    [Singleton(typeof(IGenericService<>), typeof(GenericService<>))]
+    public partial class IsServiceWithGenericsTestProvider;
+}

--- a/Inject.NET/Inject.NET.csproj
+++ b/Inject.NET/Inject.NET.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
       <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.1" />
     </ItemGroup>
 

--- a/Inject.NET/Services/ServiceScope.cs
+++ b/Inject.NET/Services/ServiceScope.cs
@@ -144,6 +144,11 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
             return ServiceProvider;
         }
 
+        if (serviceKey.Type == Types.ServiceProviderIsService)
+        {
+            return ServiceProvider;
+        }
+
         // Check if requesting IEnumerable<T> - if so, get the element type and return collection
         if (serviceKey.Type.IsIEnumerable())
         {

--- a/Inject.NET/Services/SingletonScope.cs
+++ b/Inject.NET/Services/SingletonScope.cs
@@ -77,6 +77,11 @@ where TParentServiceScope : IServiceScope
             return ServiceProvider;
         }
 
+        if (serviceKey.Type == Types.ServiceProviderIsService)
+        {
+            return ServiceProvider;
+        }
+
         var services = GetServices(serviceKey);
 
         if (services.Count == 0)

--- a/Inject.NET/Types.cs
+++ b/Inject.NET/Types.cs
@@ -8,4 +8,5 @@ public class Types
     public static readonly Type ServiceScope = typeof(IServiceScope);
     public static readonly Type ServiceProvider = typeof(IServiceProvider);
     public static readonly Type SystemServiceProvider = typeof(System.IServiceProvider);
+    public static readonly Type ServiceProviderIsService = typeof(Microsoft.Extensions.DependencyInjection.IServiceProviderIsService);
 }


### PR DESCRIPTION
## Summary
- Implemented `IServiceProviderIsService` on the `ServiceProvider` base class
- `IsService(Type)` checks built-in types, direct registrations, and open generic registrations
- `IServiceProviderIsService` itself is resolvable via dependency injection
- Required for ASP.NET Core minimal API compatibility
- 9 new integration tests

Closes #12

## Test plan
- [x] IsService returns true for registered singleton/scoped/transient types
- [x] IsService returns true for interface-to-implementation mappings
- [x] IsService returns false for unregistered types
- [x] IsService returns true for IServiceProviderIsService itself
- [x] IsService returns true for IServiceProvider
- [x] IServiceProviderIsService can be resolved from a scope
- [x] IsService returns true for open generic registrations
- [x] All 123 tests pass