### PR TITLE
feat: Support Func<T> auto-resolution in constructors

### DIFF
--- a/Inject.NET.SourceGenerator/Helpers/ConflictsHelper.cs
+++ b/Inject.NET.SourceGenerator/Helpers/ConflictsHelper.cs
@@ -22,6 +22,12 @@ public static class ConflictsHelper
         ServiceModel serviceModel,
         Parameter parameter)
     {
+        // Func<T> parameters defer resolution and cannot cause circular dependencies
+        if (parameter.IsFunc)
+        {
+            return false;
+        }
+
         if (!dependencies.TryGetValue(parameter.ServiceKey, out var models))
         {
             return false;

--- a/Inject.NET.SourceGenerator/Models/ServiceModel.cs
+++ b/Inject.NET.SourceGenerator/Models/ServiceModel.cs
@@ -30,6 +30,7 @@ public record ServiceModel
     public IEnumerable<ServiceModel> GetAllNestedParameters(IDictionary<ServiceModelCollection.ServiceKey, List<ServiceModel>> dependencyDictionary)
     {
         foreach (var serviceModel in Parameters
+                     .Where(x => !x.IsFunc) // Func<T> defers resolution, so skip it for nested parameter analysis
                      .Where(x => dependencyDictionary.Keys.Select(k => k.Type).Contains(x.Type, SymbolEqualityComparer.Default))
                      .SelectMany(x => dependencyDictionary[new ServiceModelCollection.ServiceKey(x.Type, x.Key)]))
         {

--- a/Inject.NET.SourceGenerator/Service.cs
+++ b/Inject.NET.SourceGenerator/Service.cs
@@ -48,11 +48,15 @@ public record Parameter
     public required bool IsEnumerable { get; init; }
     public bool IsLazy { get; init; }
     public ITypeSymbol? LazyInnerType { get; init; }
+    public bool IsFunc { get; init; }
+    public ITypeSymbol? FuncInnerType { get; init; }
     public string? Key { get; init; }
 
     public ServiceModelCollection.ServiceKey ServiceKey => IsLazy && LazyInnerType != null
         ? new(LazyInnerType, Key)
-        : new(Type, Key);
+        : IsFunc && FuncInnerType != null
+            ? new(FuncInnerType, Key)
+            : new(Type, Key);
 
     public string WriteSource()
     {

--- a/Inject.NET.SourceGenerator/Writers/ScopeWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/ScopeWriter.cs
@@ -220,6 +220,22 @@ internal static class ScopeWriter
                     decoratorParams.Add($"new global::System.Lazy<{innerType.GloballyQualified()}>(() => GetRequiredService<{innerType.GloballyQualified()}>())");
                 }
             }
+            else if (param.IsFunc && param.FuncInnerType != null)
+            {
+                // Handle Func<T> parameters
+                var innerType = param.FuncInnerType;
+                var innerServiceKey = new ServiceModelCollection.ServiceKey(innerType, param.Key);
+                if (rootServiceModelCollection.Services.TryGetValue(innerServiceKey, out var funcServiceModels))
+                {
+                    var funcServiceModel = funcServiceModels[^1];
+                    var resolution = TypeHelper.GetOrConstructType(rootServiceModelCollection.ServiceProviderType, rootServiceModelCollection.Services, funcServiceModel, Lifetime.Scoped);
+                    decoratorParams.Add($"new global::System.Func<{innerType.GloballyQualified()}>(() => {resolution})");
+                }
+                else
+                {
+                    decoratorParams.Add($"new global::System.Func<{innerType.GloballyQualified()}>(() => GetRequiredService<{innerType.GloballyQualified()}>())");
+                }
+            }
             else
             {
                 // This is another dependency - resolve it normally

--- a/Inject.NET.Tests/FuncTests.cs
+++ b/Inject.NET.Tests/FuncTests.cs
@@ -1,0 +1,167 @@
+using Inject.NET.Attributes;
+using Inject.NET.Extensions;
+
+namespace Inject.NET.Tests;
+
+public partial class FuncTests
+{
+    [Test]
+    public async Task Func_Singleton_ReturnsSameInstanceEachCall()
+    {
+        await using var serviceProvider = await FuncServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var factory = scope.GetRequiredService<SingletonConsumer>();
+        var a = factory.GetSingleton();
+        var b = factory.GetSingleton();
+
+        await Assert.That(a.Id).IsEqualTo(b.Id);
+    }
+
+    [Test]
+    public async Task Func_Singleton_SameAcrossScopes()
+    {
+        await using var serviceProvider = await FuncServiceProvider.BuildAsync();
+        await using var scope1 = serviceProvider.CreateScope();
+        await using var scope2 = serviceProvider.CreateScope();
+
+        var consumer1 = scope1.GetRequiredService<SingletonConsumer>();
+        var consumer2 = scope2.GetRequiredService<SingletonConsumer>();
+
+        var a = consumer1.GetSingleton();
+        var b = consumer2.GetSingleton();
+
+        await Assert.That(a.Id).IsEqualTo(b.Id);
+    }
+
+    [Test]
+    public async Task Func_Transient_ReturnsNewInstanceEachCall()
+    {
+        await using var serviceProvider = await FuncServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var factory = scope.GetRequiredService<TransientConsumer>();
+        var a = factory.GetTransient();
+        var b = factory.GetTransient();
+
+        await Assert.That(a.Id).IsNotEqualTo(b.Id);
+    }
+
+    [Test]
+    public async Task Func_Scoped_ReturnsSameInstanceWithinScope()
+    {
+        await using var serviceProvider = await FuncServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var factory = scope.GetRequiredService<ScopedConsumer>();
+        var a = factory.GetScoped();
+        var b = factory.GetScoped();
+
+        await Assert.That(a.Id).IsEqualTo(b.Id);
+    }
+
+    [Test]
+    public async Task Func_Scoped_DifferentInstancesAcrossScopes()
+    {
+        await using var serviceProvider = await FuncServiceProvider.BuildAsync();
+        await using var scope1 = serviceProvider.CreateScope();
+        await using var scope2 = serviceProvider.CreateScope();
+
+        var consumer1 = scope1.GetRequiredService<ScopedConsumer>();
+        var consumer2 = scope2.GetRequiredService<ScopedConsumer>();
+
+        var a = consumer1.GetScoped();
+        var b = consumer2.GetScoped();
+
+        await Assert.That(a.Id).IsNotEqualTo(b.Id);
+    }
+
+    [Test]
+    public async Task Func_CanResolveViaGetService()
+    {
+        await using var serviceProvider = await FuncServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        // Test that Func<T> can be resolved via the runtime GetService(Type) path
+        var funcType = typeof(Func<SingletonClass>);
+        var result = scope.GetService(funcType);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result).IsTypeOf<Func<SingletonClass>>();
+
+        var factory = (Func<SingletonClass>)result!;
+        var instance = factory();
+
+        await Assert.That(instance).IsNotNull();
+    }
+
+    [Test]
+    public async Task Func_Interface_ReturnsCorrectImplementation()
+    {
+        await using var serviceProvider = await FuncServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var consumer = scope.GetRequiredService<InterfaceConsumer>();
+        var instance = consumer.GetService();
+
+        await Assert.That(instance).IsTypeOf<ServiceImplementation>();
+    }
+
+    // Service types
+    public class SingletonClass
+    {
+        public string Id { get; } = Guid.NewGuid().ToString("N");
+    }
+
+    public class TransientClass
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    public class ScopedClass
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    public interface IMyService
+    {
+        string Name { get; }
+    }
+
+    public class ServiceImplementation : IMyService
+    {
+        public string Name => "Implementation";
+    }
+
+    // Consumer types that use Func<T>
+    public class SingletonConsumer(Func<SingletonClass> singletonFactory)
+    {
+        public SingletonClass GetSingleton() => singletonFactory();
+    }
+
+    public class TransientConsumer(Func<TransientClass> transientFactory)
+    {
+        public TransientClass GetTransient() => transientFactory();
+    }
+
+    public class ScopedConsumer(Func<ScopedClass> scopedFactory)
+    {
+        public ScopedClass GetScoped() => scopedFactory();
+    }
+
+    public class InterfaceConsumer(Func<IMyService> serviceFactory)
+    {
+        public IMyService GetService() => serviceFactory();
+    }
+
+    [ServiceProvider]
+    [Singleton<SingletonClass>]
+    [Transient<TransientClass>]
+    [Scoped<ScopedClass>]
+    [Singleton<IMyService, ServiceImplementation>]
+    [Scoped<SingletonConsumer>]
+    [Scoped<TransientConsumer>]
+    [Scoped<ScopedConsumer>]
+    [Scoped<InterfaceConsumer>]
+    public partial class FuncServiceProvider;
+}

--- a/Inject.NET/Extensions/TypeExtensions.cs
+++ b/Inject.NET/Extensions/TypeExtensions.cs
@@ -4,6 +4,7 @@ public static class TypeExtensions
 {
     private static readonly Type EnumerableGeneric = typeof(IEnumerable<>);
     private static readonly Type LazyGeneric = typeof(Lazy<>);
+    private static readonly Type FuncGeneric = typeof(Func<>);
 
     public static bool IsIEnumerable(this Type type)
     {
@@ -15,5 +16,12 @@ public static class TypeExtensions
     {
         return type.IsGenericType
                && type.GetGenericTypeDefinition() == LazyGeneric;
+    }
+
+    public static bool IsFunc(this Type type)
+    {
+        return type.IsGenericType
+               && type.GetGenericArguments().Length == 1
+               && type.GetGenericTypeDefinition() == FuncGeneric;
     }
 }

--- a/Inject.NET/Services/ServiceScope.cs
+++ b/Inject.NET/Services/ServiceScope.cs
@@ -107,7 +107,37 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
             return lazyFactory.GetMethod("Create")!.Invoke(factory, null);
         }
 
+        // Handle Func<T> - create a factory delegate that resolves T on each call
+        if (type.IsFunc())
+        {
+            var innerType = type.GetGenericArguments()[0];
+            return CreateFuncFactory(innerType);
+        }
+
         return GetService(serviceKey);
+    }
+
+    /// <summary>
+    /// Creates a Func&lt;T&gt; delegate that resolves the inner type from this scope.
+    /// </summary>
+    private object CreateFuncFactory(Type innerType)
+    {
+        var serviceKey = new ServiceKey(innerType);
+        // Use Delegate.CreateDelegate equivalent via expression:
+        // Build a Func<T> that calls GetService(serviceKey) and casts to T
+        var scope = this;
+        Func<object?> objectFactory = () => scope.GetService(serviceKey);
+
+        // Create a properly typed Func<T> via the generic helper method
+        var createMethod = typeof(ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope, TParentSingletonScope, TParentServiceProvider>)
+            .GetMethod(nameof(WrapFuncFactory), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .MakeGenericMethod(innerType);
+        return createMethod.Invoke(null, [objectFactory])!;
+    }
+
+    private static Func<T> WrapFuncFactory<T>(Func<object?> factory)
+    {
+        return () => (T)factory()!;
     }
 
     /// <summary>
@@ -149,6 +179,13 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
         {
             var elementType = serviceKey.Type.GetGenericArguments()[0];
             return GetServices(serviceKey with { Type = elementType });
+        }
+
+        // Handle Func<T> - create a factory delegate that resolves T on each call
+        if (serviceKey.Type.IsFunc())
+        {
+            var innerType = serviceKey.Type.GetGenericArguments()[0];
+            return CreateFuncFactory(innerType);
         }
 
         if (_cachedEnumerables?.TryGetValue(serviceKey, out var cachedEnumerable) == true


### PR DESCRIPTION
## Summary
- Source generator now detects `Func<T>` constructor parameters and generates `new Func<T>(() => ...)` factory wrappers
- Supports all lifetimes: singleton (same instance), scoped (scoped instance), transient (new instance per call)
- Runtime `GetService(typeof(Func<T>))` support for dynamic resolution
- Captive dependency safety: `Func<Transient>` in a scoped consumer doesn't trigger captive dependency errors
- Circular dependency detection skips `Func<T>` parameters (deferred resolution breaks cycles)
- 7 new integration tests + 15 updated snapshot files

Closes #7

## Test plan
- [x] Func<T> with singleton returns same instance each call
- [x] Func<T> with singleton same across scopes
- [x] Func<T> with transient returns new instance each call
- [x] Func<T> with scoped returns same instance within scope
- [x] Func<T> with scoped returns different instances across scopes
- [x] Func<T> resolvable via GetService at runtime
- [x] Func<IService> resolves correct implementation
- [x] All integration and snapshot tests pass