### PR TITLE
feat: Support Composite pattern for multi-implementation services

### DIFF
--- a/Inject.NET.SourceGenerator/CompositeDictionary.cs
+++ b/Inject.NET.SourceGenerator/CompositeDictionary.cs
@@ -1,0 +1,146 @@
+using Inject.NET.SourceGenerator.Models;
+using Microsoft.CodeAnalysis;
+
+namespace Inject.NET.SourceGenerator;
+
+internal static class CompositeDictionary
+{
+    /// <summary>
+    /// Creates a dictionary of composites from the provided attribute data.
+    /// </summary>
+    /// <param name="compilation">The compilation context for type resolution.</param>
+    /// <param name="compositeAttributes">Array of composite attributes to process.</param>
+    /// <param name="tenantName">Optional tenant name for multi-tenant scenarios.</param>
+    /// <returns>A dictionary mapping service keys to composite models.</returns>
+    public static IDictionary<ServiceModelCollection.ServiceKey, CompositeModel> Create(
+        Compilation compilation,
+        AttributeData[] compositeAttributes,
+        string? tenantName)
+    {
+        var composites = new Dictionary<ServiceModelCollection.ServiceKey, CompositeModel>();
+
+        foreach (var attributeData in compositeAttributes)
+        {
+            if (attributeData.AttributeClass is null)
+                continue;
+
+            // Extract service type and composite type
+            INamedTypeSymbol? serviceType = null;
+            INamedTypeSymbol? compositeType = null;
+
+            // Check if it's a generic composite attribute (CompositeAttribute<TService, TComposite>)
+            if (attributeData.AttributeClass.IsGenericType && attributeData.AttributeClass.TypeArguments.Length == 2)
+            {
+                serviceType = attributeData.AttributeClass.TypeArguments[0] as INamedTypeSymbol;
+                compositeType = attributeData.AttributeClass.TypeArguments[1] as INamedTypeSymbol;
+            }
+            else if (attributeData.ConstructorArguments.Length >= 2)
+            {
+                // Non-generic: Composite(typeof(IService), typeof(CompositeService))
+                serviceType = attributeData.ConstructorArguments[0].Value as INamedTypeSymbol;
+                compositeType = attributeData.ConstructorArguments[1].Value as INamedTypeSymbol;
+            }
+
+            if (serviceType is null || compositeType is null)
+                continue;
+
+            // Extract Key property if present
+            string? key = null;
+            foreach (var namedArg in attributeData.NamedArguments)
+            {
+                if (namedArg.Key == "Key")
+                {
+                    key = namedArg.Value.Value as string;
+                }
+            }
+
+            // Get constructor parameters for the composite
+            var constructors = compositeType.Constructors
+                .Where(c => !c.IsStatic && c.DeclaredAccessibility == Accessibility.Public)
+                .OrderByDescending(c => c.Parameters.Length)
+                .ToArray();
+
+            if (constructors.Length == 0)
+                continue;
+
+            var constructor = constructors[0];
+            var parameters = constructor.Parameters
+                .Select(p => new Parameter
+                {
+                    Type = p.Type,
+                    DefaultValue = p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null,
+                    IsOptional = p.IsOptional,
+                    IsNullable = p.NullableAnnotation == NullableAnnotation.Annotated,
+                    IsEnumerable = CheckIsEnumerable(p.Type, compilation),
+                    IsLazy = CheckIsLazy(p.Type, out var lazyInnerType),
+                    LazyInnerType = lazyInnerType,
+                    IsFunc = CheckIsFunc(p.Type, out var funcInnerType),
+                    FuncInnerType = funcInnerType,
+                    Key = null
+                })
+                .ToArray();
+
+            var compositeModel = new CompositeModel
+            {
+                ServiceType = serviceType,
+                CompositeType = compositeType,
+                Parameters = parameters,
+                Key = key,
+                TenantName = tenantName
+            };
+
+            var serviceKey = new ServiceModelCollection.ServiceKey(serviceType, key);
+            composites[serviceKey] = compositeModel;
+        }
+
+        return composites;
+    }
+
+    private static bool CheckIsEnumerable(ITypeSymbol parameterType, Compilation compilation)
+    {
+        var enumerableType = compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T);
+
+        if (parameterType is INamedTypeSymbol { IsGenericType: true } namedType &&
+            SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, enumerableType))
+        {
+            return true;
+        }
+
+        foreach (var interfaceType in parameterType.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(interfaceType.OriginalDefinition, enumerableType))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool CheckIsLazy(ITypeSymbol parameterType, out ITypeSymbol? innerType)
+    {
+        if (parameterType is INamedTypeSymbol { IsGenericType: true, Arity: 1 } namedType
+            && namedType.ConstructedFrom.ToDisplayString() == "System.Lazy<T>")
+        {
+            innerType = namedType.TypeArguments[0];
+            return true;
+        }
+
+        innerType = null;
+        return false;
+    }
+
+    private static bool CheckIsFunc(ITypeSymbol parameterType, out ITypeSymbol? innerType)
+    {
+        innerType = null;
+
+        if (parameterType is INamedTypeSymbol { IsGenericType: true } namedType
+            && namedType.TypeArguments.Length == 1
+            && namedType.OriginalDefinition.ToDisplayString() == "System.Func<TResult>")
+        {
+            innerType = namedType.TypeArguments[0];
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Inject.NET.SourceGenerator/Models/CompositeModel.cs
+++ b/Inject.NET.SourceGenerator/Models/CompositeModel.cs
@@ -1,0 +1,18 @@
+using Microsoft.CodeAnalysis;
+
+namespace Inject.NET.SourceGenerator.Models;
+
+public record CompositeModel
+{
+    public required INamedTypeSymbol ServiceType { get; init; }
+
+    public required INamedTypeSymbol CompositeType { get; init; }
+
+    public required Parameter[] Parameters { get; init; }
+
+    public required string? Key { get; init; }
+
+    public required string? TenantName { get; init; }
+
+    public ServiceModelCollection.ServiceKey ServiceKey => new(ServiceType, Key);
+}

--- a/Inject.NET.SourceGenerator/Writers/ScopeWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/ScopeWriter.cs
@@ -14,7 +14,7 @@ internal static class ScopeWriter
     /// <param name="serviceProviderModel">The service provider model containing type information.</param>
     /// <param name="rootServiceModelCollection">The collection of all root service models.</param>
     public static void Write(SourceCodeWriter sourceCodeWriter, TypedServiceProviderModel serviceProviderModel,
-        RootServiceModelCollection rootServiceModelCollection, IDictionary<ServiceModelCollection.ServiceKey, List<DecoratorModel>> decorators = null)
+        RootServiceModelCollection rootServiceModelCollection, IDictionary<ServiceModelCollection.ServiceKey, List<DecoratorModel>> decorators = null, IDictionary<ServiceModelCollection.ServiceKey, CompositeModel> composites = null)
     {
         sourceCodeWriter.WriteLine(
             $"public class ServiceScope_ : global::Inject.NET.Services.ServiceScope<{serviceProviderModel.Prefix}ServiceScope_, {serviceProviderModel.Prefix}ServiceProvider_, {serviceProviderModel.Prefix}SingletonScope_, {serviceProviderModel.Prefix}ServiceScope_, {serviceProviderModel.Prefix}SingletonScope_, {serviceProviderModel.Prefix}ServiceProvider_>");

--- a/Inject.NET.SourceGenerator/Writers/ServiceRegistrarWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/ServiceRegistrarWriter.cs
@@ -6,7 +6,8 @@ internal static class ServiceRegistrarWriter
 {
     public static void Write(SourceCodeWriter sourceCodeWriter, TypedServiceProviderModel serviceProviderModel,
         IDictionary<ServiceModelCollection.ServiceKey, List<ServiceModel>> dependencyDictionary,
-        IDictionary<ServiceModelCollection.ServiceKey, List<DecoratorModel>>? decorators = null)
+        IDictionary<ServiceModelCollection.ServiceKey, List<DecoratorModel>>? decorators = null,
+        IDictionary<ServiceModelCollection.ServiceKey, CompositeModel>? composites = null)
     {
         sourceCodeWriter.WriteLine(
             $"public partial class ServiceRegistrar_ : global::Inject.NET.Services.ServiceRegistrar<{serviceProviderModel.Prefix}ServiceProvider_, {serviceProviderModel.Prefix}ServiceProvider_>");
@@ -17,6 +18,7 @@ internal static class ServiceRegistrarWriter
         sourceCodeWriter.WriteLine("{");
 
         WriteRegistration(sourceCodeWriter, dependencyDictionary, decorators, string.Empty);
+        WriteCompositeRegistrations(sourceCodeWriter, dependencyDictionary, composites, string.Empty);
 
         // Call user-defined configuration hook for extension method registrations
         sourceCodeWriter.WriteLine("ConfigureServices();");
@@ -310,5 +312,94 @@ internal static class ServiceRegistrarWriter
         }
 
         return $"new {decorator.DecoratorType.GloballyQualified()}({string.Join(", ", decoratorParams)})";
+    }
+
+    private static void WriteCompositeRegistrations(SourceCodeWriter sourceCodeWriter,
+        IDictionary<ServiceModelCollection.ServiceKey, List<ServiceModel>> dependencyDictionary,
+        IDictionary<ServiceModelCollection.ServiceKey, CompositeModel>? composites,
+        string prefix)
+    {
+        if (composites is null || composites.Count == 0)
+            return;
+
+        foreach (var (serviceKey, composite) in composites)
+        {
+            // Determine lifetime from the existing registrations for this service type
+            var lifetime = Lifetime.Singleton;
+            if (dependencyDictionary.TryGetValue(serviceKey, out var existingModels) && existingModels.Count > 0)
+            {
+                lifetime = existingModels[0].Lifetime;
+            }
+
+            sourceCodeWriter.WriteLine($"{prefix}Register(new global::Inject.NET.Models.ServiceDescriptor");
+            sourceCodeWriter.WriteLine("{");
+            sourceCodeWriter.WriteLine($"ServiceType = typeof({composite.ServiceType.GloballyQualified()}),");
+            sourceCodeWriter.WriteLine($"ImplementationType = typeof({composite.CompositeType.GloballyQualified()}),");
+            sourceCodeWriter.WriteLine($"Lifetime = Inject.NET.Enums.Lifetime.{lifetime.ToString()},");
+            sourceCodeWriter.WriteLine($"IsComposite = true,");
+
+            if (composite.Key is not null)
+            {
+                sourceCodeWriter.WriteLine($"Key = \"{composite.Key}\",");
+            }
+
+            sourceCodeWriter.WriteLine("Factory = (scope, type, key) =>");
+
+            // Build parameters for the composite constructor
+            var compositeParams = BuildCompositeParameters(composite);
+            sourceCodeWriter.WriteLine($"new {composite.CompositeType.GloballyQualified()}({string.Join(", ", compositeParams)})");
+            sourceCodeWriter.WriteLine("});");
+            sourceCodeWriter.WriteLine();
+        }
+    }
+
+    private static IEnumerable<string> BuildCompositeParameters(CompositeModel composite)
+    {
+        foreach (var param in composite.Parameters)
+        {
+            // Check if this parameter is IEnumerable<TService> - this is the collection of non-composite implementations
+            if (param.IsEnumerable)
+            {
+                var elementType = param.Type is Microsoft.CodeAnalysis.INamedTypeSymbol { IsGenericType: true } genericType
+                    ? genericType.TypeArguments[0]
+                    : param.Type;
+
+                // Check if the enumerable element type matches the composite's service type
+                if (Microsoft.CodeAnalysis.SymbolEqualityComparer.Default.Equals(elementType, composite.ServiceType))
+                {
+                    // Use GetServices which will exclude the composite itself (due to IsComposite flag)
+                    var key = param.Key is null ? "null" : $"\"{param.Key}\"";
+                    yield return $"[..scope.GetServices<{elementType.GloballyQualified()}>({key})]";
+                }
+                else
+                {
+                    // Regular enumerable parameter
+                    var key = param.Key is null ? "null" : $"\"{param.Key}\"";
+                    yield return $"[..scope.GetServices<{elementType.GloballyQualified()}>({key})]";
+                }
+            }
+            else if (param.IsLazy && param.LazyInnerType != null)
+            {
+                var innerType = param.LazyInnerType;
+                yield return $"new global::System.Lazy<{innerType.GloballyQualified()}>(() => scope.GetRequiredService<{innerType.GloballyQualified()}>())";
+            }
+            else if (param.IsFunc && param.FuncInnerType != null)
+            {
+                var innerType = param.FuncInnerType;
+                yield return $"new global::System.Func<{innerType.GloballyQualified()}>(() => scope.GetRequiredService<{innerType.GloballyQualified()}>())";
+            }
+            else if (param.IsOptional)
+            {
+                yield return $"scope.GetOptionalService<{param.Type.GloballyQualified()}>() ?? {param.DefaultValue ?? "default"}";
+            }
+            else if (param.IsNullable)
+            {
+                yield return $"scope.GetOptionalService<{param.Type.GloballyQualified()}>()";
+            }
+            else
+            {
+                yield return $"scope.GetRequiredService<{param.Type.GloballyQualified()}>()";
+            }
+        }
     }
 }

--- a/Inject.NET.Tests/CompositeTests.cs
+++ b/Inject.NET.Tests/CompositeTests.cs
@@ -1,0 +1,258 @@
+using Inject.NET.Attributes;
+using Inject.NET.Extensions;
+
+namespace Inject.NET.Tests;
+
+public partial class CompositeTests
+{
+    [Test]
+    public async Task Composite_IsReturnedWhenResolvingSingleService()
+    {
+        await using var serviceProvider = await CompositeServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var sender = scope.GetRequiredService<INotificationSender>();
+
+        await Assert.That(sender).IsTypeOf<CompositeNotificationSender>();
+    }
+
+    [Test]
+    public async Task Composite_IsExcludedFromEnumerableResolution()
+    {
+        await using var serviceProvider = await CompositeServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var senders = scope.GetServices<INotificationSender>().ToList();
+
+        await Assert.That(senders).HasCount().EqualTo(2);
+        await Assert.That(senders[0]).IsTypeOf<EmailSender>();
+        await Assert.That(senders[1]).IsTypeOf<SmsSender>();
+    }
+
+    [Test]
+    public async Task Composite_ReceivesAllOtherImplementations()
+    {
+        await using var serviceProvider = await CompositeServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var sender = scope.GetRequiredService<INotificationSender>();
+        var composite = (CompositeNotificationSender)sender;
+
+        await Assert.That(composite.Senders.Count).IsEqualTo(2);
+        await Assert.That(composite.Senders[0]).IsTypeOf<EmailSender>();
+        await Assert.That(composite.Senders[1]).IsTypeOf<SmsSender>();
+    }
+
+    [Test]
+    public async Task Composite_WithScopedServices()
+    {
+        await using var serviceProvider = await ScopedCompositeServiceProvider.BuildAsync();
+
+        await using var scope1 = serviceProvider.CreateScope();
+        var handler1 = scope1.GetRequiredService<IHandler>();
+
+        await using var scope2 = serviceProvider.CreateScope();
+        var handler2 = scope2.GetRequiredService<IHandler>();
+
+        await Assert.That(handler1).IsTypeOf<CompositeHandler>();
+        await Assert.That(handler2).IsTypeOf<CompositeHandler>();
+
+        // Different scopes should get different composite instances
+        await Assert.That(handler1).IsNotSameReferenceAs(handler2);
+    }
+
+    [Test]
+    public async Task Composite_WithScopedServices_EnumerableExcludesComposite()
+    {
+        await using var serviceProvider = await ScopedCompositeServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var handlers = scope.GetServices<IHandler>().ToList();
+
+        await Assert.That(handlers).HasCount().EqualTo(2);
+        await Assert.That(handlers[0]).IsTypeOf<HandlerA>();
+        await Assert.That(handlers[1]).IsTypeOf<HandlerB>();
+    }
+
+    [Test]
+    public async Task Composite_WithNonGenericAttribute()
+    {
+        await using var serviceProvider = await NonGenericCompositeServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var sender = scope.GetRequiredService<INotificationSender>();
+
+        await Assert.That(sender).IsTypeOf<CompositeNotificationSender>();
+
+        var senders = scope.GetServices<INotificationSender>().ToList();
+        await Assert.That(senders).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Composite_WithTransientServices()
+    {
+        await using var serviceProvider = await TransientCompositeServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var processor1 = scope.GetRequiredService<IProcessor>();
+        var processor2 = scope.GetRequiredService<IProcessor>();
+
+        await Assert.That(processor1).IsTypeOf<CompositeProcessor>();
+        await Assert.That(processor2).IsTypeOf<CompositeProcessor>();
+
+        // Transient services should be new instances each time
+        await Assert.That(processor1).IsNotSameReferenceAs(processor2);
+    }
+
+    [Test]
+    public async Task Composite_WithTransientServices_EnumerableExcludesComposite()
+    {
+        await using var serviceProvider = await TransientCompositeServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var processors = scope.GetServices<IProcessor>().ToList();
+
+        await Assert.That(processors).HasCount().EqualTo(2);
+        await Assert.That(processors[0]).IsTypeOf<ProcessorA>();
+        await Assert.That(processors[1]).IsTypeOf<ProcessorB>();
+    }
+
+    // Service Providers
+
+    [ServiceProvider]
+    [Singleton<INotificationSender, EmailSender>]
+    [Singleton<INotificationSender, SmsSender>]
+    [Composite<INotificationSender, CompositeNotificationSender>]
+    public partial class CompositeServiceProvider;
+
+    [ServiceProvider]
+    [Scoped<IHandler, HandlerA>]
+    [Scoped<IHandler, HandlerB>]
+    [Composite<IHandler, CompositeHandler>]
+    public partial class ScopedCompositeServiceProvider;
+
+    [ServiceProvider]
+    [Singleton<INotificationSender, EmailSender>]
+    [Singleton<INotificationSender, SmsSender>]
+    [Composite(typeof(INotificationSender), typeof(CompositeNotificationSender))]
+    public partial class NonGenericCompositeServiceProvider;
+
+    [ServiceProvider]
+    [Transient<IProcessor, ProcessorA>]
+    [Transient<IProcessor, ProcessorB>]
+    [Composite<IProcessor, CompositeProcessor>]
+    public partial class TransientCompositeServiceProvider;
+
+    // Interfaces and Implementations
+
+    public interface INotificationSender
+    {
+        Task SendAsync(string message);
+    }
+
+    public class EmailSender : INotificationSender
+    {
+        public Task SendAsync(string message)
+        {
+            Console.WriteLine($"Email: {message}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class SmsSender : INotificationSender
+    {
+        public Task SendAsync(string message)
+        {
+            Console.WriteLine($"SMS: {message}");
+            return Task.CompletedTask;
+        }
+    }
+
+    public class CompositeNotificationSender : INotificationSender
+    {
+        public IReadOnlyList<INotificationSender> Senders { get; }
+
+        public CompositeNotificationSender(IEnumerable<INotificationSender> senders)
+        {
+            Senders = senders.ToList();
+        }
+
+        public async Task SendAsync(string message)
+        {
+            foreach (var sender in Senders)
+            {
+                await sender.SendAsync(message);
+            }
+        }
+    }
+
+    // Scoped composite types
+
+    public interface IHandler
+    {
+        void Handle();
+    }
+
+    public class HandlerA : IHandler
+    {
+        public void Handle() => Console.WriteLine("Handler A");
+    }
+
+    public class HandlerB : IHandler
+    {
+        public void Handle() => Console.WriteLine("Handler B");
+    }
+
+    public class CompositeHandler : IHandler
+    {
+        public IReadOnlyList<IHandler> Handlers { get; }
+
+        public CompositeHandler(IEnumerable<IHandler> handlers)
+        {
+            Handlers = handlers.ToList();
+        }
+
+        public void Handle()
+        {
+            foreach (var handler in Handlers)
+            {
+                handler.Handle();
+            }
+        }
+    }
+
+    // Transient composite types
+
+    public interface IProcessor
+    {
+        void Process();
+    }
+
+    public class ProcessorA : IProcessor
+    {
+        public void Process() => Console.WriteLine("Processor A");
+    }
+
+    public class ProcessorB : IProcessor
+    {
+        public void Process() => Console.WriteLine("Processor B");
+    }
+
+    public class CompositeProcessor : IProcessor
+    {
+        public IReadOnlyList<IProcessor> Processors { get; }
+
+        public CompositeProcessor(IEnumerable<IProcessor> processors)
+        {
+            Processors = processors.ToList();
+        }
+
+        public void Process()
+        {
+            foreach (var processor in Processors)
+            {
+                processor.Process();
+            }
+        }
+    }
+}

--- a/Inject.NET/Attributes/CompositeAttribute.cs
+++ b/Inject.NET/Attributes/CompositeAttribute.cs
@@ -1,0 +1,71 @@
+namespace Inject.NET.Attributes;
+
+/// <summary>
+/// Registers a composite that wraps all other registrations of a service type.
+/// A composite receives all non-composite implementations via IEnumerable&lt;T&gt; constructor injection.
+/// When resolving the service type (singular), the composite is returned.
+/// When resolving IEnumerable&lt;T&gt;, the composite is excluded.
+/// </summary>
+/// <example>
+/// <code>
+/// [ServiceProvider]
+/// [Singleton&lt;INotificationSender, EmailSender&gt;]
+/// [Singleton&lt;INotificationSender, SmsSender&gt;]
+/// [Composite(typeof(INotificationSender), typeof(CompositeNotificationSender))]
+/// public partial class ServiceContainer;
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class CompositeAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the service type to create a composite for.
+    /// </summary>
+    public Type ServiceType { get; }
+
+    /// <summary>
+    /// Gets the composite implementation type.
+    /// </summary>
+    public Type CompositeType { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the CompositeAttribute class.
+    /// </summary>
+    /// <param name="serviceType">The service type to create a composite for</param>
+    /// <param name="compositeType">The composite implementation type</param>
+    public CompositeAttribute(Type serviceType, Type compositeType)
+    {
+        ServiceType = serviceType;
+        CompositeType = compositeType;
+    }
+}
+
+/// <summary>
+/// Registers a composite with compile-time type safety that wraps all other registrations of a service type.
+/// The composite receives all non-composite implementations via IEnumerable&lt;T&gt; constructor injection.
+/// When resolving the service type (singular), the composite is returned.
+/// When resolving IEnumerable&lt;T&gt;, the composite is excluded.
+/// </summary>
+/// <typeparam name="TService">The service type interface or base class</typeparam>
+/// <typeparam name="TComposite">The composite implementation type</typeparam>
+/// <example>
+/// <code>
+/// [ServiceProvider]
+/// [Singleton&lt;INotificationSender, EmailSender&gt;]
+/// [Singleton&lt;INotificationSender, SmsSender&gt;]
+/// [Composite&lt;INotificationSender, CompositeNotificationSender&gt;]
+/// public partial class ServiceContainer;
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class CompositeAttribute<TService, TComposite> : CompositeAttribute
+    where TService : class
+    where TComposite : class, TService
+{
+    /// <summary>
+    /// Initializes a new instance of the CompositeAttribute class.
+    /// </summary>
+    public CompositeAttribute() : base(typeof(TService), typeof(TComposite))
+    {
+    }
+}

--- a/Inject.NET/Models/ServiceDescriptor.cs
+++ b/Inject.NET/Models/ServiceDescriptor.cs
@@ -9,5 +9,6 @@ public class ServiceDescriptor
     public required Type ImplementationType { get; init; }
     public required Lifetime Lifetime { get; init; }
     public string? Key { get; init; }
+    public bool IsComposite { get; init; }
     public required Func<IServiceScope, Type, string?, object> Factory { get; init; }
 }

--- a/Inject.NET/Services/ServiceScope.cs
+++ b/Inject.NET/Services/ServiceScope.cs
@@ -193,13 +193,9 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
             return CreateFuncFactory(innerType);
         }
 
-        if (_cachedEnumerables?.TryGetValue(serviceKey, out var cachedEnumerable) == true
-            && cachedEnumerable.Count > 0)
-        {
-            return cachedEnumerable[^1];
-        }
-
-        if (!_serviceFactories.Descriptor.TryGetValue(serviceKey, out var descriptor))
+        // Look up the descriptor to check for composites
+        ServiceDescriptor? descriptor = null;
+        if (!_serviceFactories.Descriptor.TryGetValue(serviceKey, out descriptor))
         {
             if (!_serviceFactories.LateBoundGenericDescriptor.TryGetValue(serviceKey, out descriptor))
             {
@@ -207,11 +203,26 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
                     !_serviceFactories.Descriptor.TryGetValue(
                         serviceKey with { Type = serviceKey.Type.GetGenericTypeDefinition() }, out descriptor))
                 {
+                    // No descriptor found - try cached enumerables before parent
+                    if (_cachedEnumerables?.TryGetValue(serviceKey, out var cachedEnumerable) == true
+                        && cachedEnumerable.Count > 0)
+                    {
+                        return cachedEnumerable[^1];
+                    }
+
                     return ParentScope?.GetService(serviceKey, originatingScope);
                 }
 
                 _serviceFactories.LateBoundGenericDescriptor[serviceKey] = descriptor;
             }
+        }
+
+        // For non-composite services, check cached enumerables as optimization
+        if (!descriptor.IsComposite
+            && _cachedEnumerables?.TryGetValue(serviceKey, out var cached) == true
+            && cached.Count > 0)
+        {
+            return cached[^1];
         }
 
         if (descriptor.Lifetime == Lifetime.Singleton)
@@ -221,7 +232,7 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
 
         var obj = descriptor.Factory(originatingScope, serviceKey.Type, descriptor.Key);
 
-            
+
         if(descriptor.Lifetime != Lifetime.Transient)
         {
             (_cachedObjects ??= Pools.Objects.Get())[serviceKey] = obj;
@@ -283,7 +294,17 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
         {
             var serviceDescriptor = factories.Items[i];
             var lifetime = serviceDescriptor.Lifetime;
-            
+
+            // Skip composite services when resolving IEnumerable<T>
+            if (serviceDescriptor.IsComposite)
+            {
+                if (lifetime == Lifetime.Singleton)
+                {
+                    singletonIndex++;
+                }
+                continue;
+            }
+
             object? item;
             if (lifetime == Lifetime.Singleton)
             {
@@ -292,20 +313,20 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
             else
             {
                 item = serviceDescriptor.Factory(scope, serviceKey.Type, serviceDescriptor.Key);
-                
+
                 if(item is IAsyncDisposable or IDisposable)
                 {
                     (_forDisposal ??= Pools.DisposalTracker.Get()).Add(item);
                 }
             }
-            
+
             if(lifetime != Lifetime.Transient)
             {
                 if (!cachedEnumerables.TryGetValue(serviceKey, out var items))
                 {
                     cachedEnumerables[serviceKey] = items = [];
                 }
-                
+
                 items.Add(item);
             }
 

--- a/Inject.NET/Services/SingletonScope.cs
+++ b/Inject.NET/Services/SingletonScope.cs
@@ -71,7 +71,7 @@ where TParentServiceScope : IServiceScope
         {
             return this;
         }
-        
+
         if (serviceKey.Type == Types.ServiceProvider || serviceKey.Type == Types.SystemServiceProvider)
         {
             return ServiceProvider;
@@ -82,14 +82,35 @@ where TParentServiceScope : IServiceScope
             return ServiceProvider;
         }
 
+        // Check if there's a composite descriptor for this service key
+        // If so, resolve the composite directly instead of going through GetServices
+        // (which excludes composites from enumerable resolution)
+        if (serviceFactories.Descriptor.TryGetValue(serviceKey, out var descriptor) && descriptor.IsComposite)
+        {
+            return GetOrCreateComposite(serviceKey, descriptor, originatingScope);
+        }
+
         var services = GetServices(serviceKey);
 
         if (services.Count == 0)
         {
             return ParentScope?.GetService(serviceKey, originatingScope);
         }
-        
+
         return services[^1];
+    }
+
+    private readonly ConcurrentDictionary<ServiceKey, object> _compositeCache = new();
+
+    private object GetOrCreateComposite(ServiceKey serviceKey, ServiceDescriptor descriptor, IServiceScope originatingScope)
+    {
+        return _compositeCache.GetOrAdd(serviceKey, (key, state) =>
+        {
+            var (self, desc, originScope) = state;
+            var obj = desc.Factory(originScope, key.Type, desc.Key);
+            self.Register(obj);
+            return obj;
+        }, (this, descriptor, originatingScope));
     }
 
     public virtual IReadOnlyList<object> GetServices(ServiceKey serviceKey, IServiceScope originatingScope)
@@ -114,9 +135,9 @@ where TParentServiceScope : IServiceScope
                 return [];
             }
 
-            // Create local singleton instances
+            // Create local singleton instances, excluding composites from enumerable resolution
             var singletonDescriptors = descriptors!.Items
-                .Where(d => d.Lifetime == Lifetime.Singleton)
+                .Where(d => d.Lifetime == Lifetime.Singleton && !d.IsComposite)
                 .ToList();
 
             var results = new List<object>(singletonDescriptors.Count);


### PR DESCRIPTION
## Summary
- Adds `[Composite<TService, TComposite>]` attribute (and non-generic `[Composite]` variant) for the Composite design pattern
- When resolving `TService` (singular), the composite is returned; when resolving `IEnumerable<TService>`, the composite is excluded to avoid circular resolution
- The composite receives all non-composite implementations via `IEnumerable<T>` constructor injection
- Supports singleton, scoped, and transient lifetimes

## Implementation
- New `CompositeAttribute` in `Inject.NET/Attributes/`
- `CompositeDictionary` parser in source generator (mirrors `DecoratorDictionary` pattern)
- `IsComposite` flag on `ServiceDescriptor` for runtime filtering
- Updated `ServiceScope` and `SingletonScope` to handle composite resolution correctly
- Updated `ServiceRegistrarWriter` to generate composite factory registrations

## Test plan
- [x] 8 new integration tests covering singleton/scoped/transient composites
- [x] Tests verify composites excluded from `IEnumerable<T>` resolution
- [x] Tests verify composite receives all implementations via constructor
- [x] All 170 tests pass (162 existing + 8 new)
- [x] Source generator snapshot tests: 17/17 passing

Closes #15