### PR TITLE
feat: Support opting out of container-managed disposal (ExternallyOwned)

### DIFF
--- a/Inject.NET.SourceGenerator/DependencyDictionary.cs
+++ b/Inject.NET.SourceGenerator/DependencyDictionary.cs
@@ -56,22 +56,26 @@ internal static class DependencyDictionary
             }
 
             string? key = null;
+            bool externallyOwned = false;
             foreach (var namedArg in attributeData.NamedArguments)
             {
                 if (namedArg.Key == "Key")
                 {
                     key = namedArg.Value.Value as string;
-                    break;
+                }
+                else if (namedArg.Key == "ExternallyOwned")
+                {
+                    externallyOwned = namedArg.Value.Value is true;
                 }
             }
             var lifetime = EnumPolyfill.Parse<Lifetime>(attributeData.AttributeClass!.Name.Replace("Attribute", string.Empty));
             var isGenericDefinition = serviceType.IsGenericDefinition();
             
-            Add(compilation, serviceType, implementationType, serviceBuilders, key, lifetime, tenantName);
+            Add(compilation, serviceType, implementationType, serviceBuilders, key, lifetime, tenantName, externallyOwned);
 
             if (isGenericDefinition)
             {
-                ProcessGenericTypes(compilation, serviceType, implementationType, serviceBuilders, key, lifetime, tenantName);
+                ProcessGenericTypes(compilation, serviceType, implementationType, serviceBuilders, key, lifetime, tenantName, externallyOwned);
             }
         }
     }
@@ -87,9 +91,9 @@ internal static class DependencyDictionary
     /// <param name="key">Optional service key for keyed services.</param>
     /// <param name="lifetime">Service lifetime scope.</param>
     /// <param name="tenantName">Optional tenant name for multi-tenant scenarios.</param>
-    private static void ProcessGenericTypes(Compilation compilation, INamedTypeSymbol serviceType, 
-        INamedTypeSymbol implementationType, List<ServiceModelBuilder> serviceBuilders, 
-        string? key, Lifetime lifetime, string? tenantName)
+    private static void ProcessGenericTypes(Compilation compilation, INamedTypeSymbol serviceType,
+        INamedTypeSymbol implementationType, List<ServiceModelBuilder> serviceBuilders,
+        string? key, Lifetime lifetime, string? tenantName, bool externallyOwned)
     {
         var constructedTypes = GenericTypeHelper.GetConstructedTypes(compilation, serviceType);
 
@@ -114,8 +118,9 @@ internal static class DependencyDictionary
                         : implementationType,
                     serviceBuilders,
                     key,
-                    lifetime, 
-                    tenantName);
+                    lifetime,
+                    tenantName,
+                    externallyOwned);
             }
         }
     }
@@ -234,7 +239,8 @@ internal static class DependencyDictionary
                     IsOpenGeneric = smb.IsOpenGeneric,
                     Parameters = parameters,
                     Index = index,
-                    TenantName = smb.TenantName
+                    TenantName = smb.TenantName,
+                    ExternallyOwned = smb.ExternallyOwned
                 });
             }
             result[kvp.Key] = serviceModels;
@@ -244,7 +250,7 @@ internal static class DependencyDictionary
     }
 
     private static void Add(Compilation compilation, INamedTypeSymbol serviceType, INamedTypeSymbol implementationType,
-        List<ServiceModelBuilder> list, string? key, Lifetime lifetime, string? tenantName)
+        List<ServiceModelBuilder> list, string? key, Lifetime lifetime, string? tenantName, bool externallyOwned)
     {
         var isGenericDefinition = serviceType.IsGenericDefinition();
 
@@ -258,7 +264,8 @@ internal static class DependencyDictionary
             Parameters = parameters,
             Key = key,
             Lifetime = lifetime,
-            TenantName = tenantName
+            TenantName = tenantName,
+            ExternallyOwned = externallyOwned
         });
     }
 

--- a/Inject.NET.SourceGenerator/Models/ServiceModel.cs
+++ b/Inject.NET.SourceGenerator/Models/ServiceModel.cs
@@ -22,6 +22,8 @@ public record ServiceModel
     
     public ServiceModelCollection.ServiceKey ServiceKey => new(ServiceType, Key);
     public required string? TenantName { get; init; }
+
+    public required bool ExternallyOwned { get; init; }
     
     // Cached property/field names for performance
     private string? _cachedPropertyName;

--- a/Inject.NET.SourceGenerator/Models/ServiceModelBuilder.cs
+++ b/Inject.NET.SourceGenerator/Models/ServiceModelBuilder.cs
@@ -16,4 +16,5 @@ public record ServiceModelBuilder
 
     public required Parameter[] Parameters { get; init; }
     public required string? TenantName { get; init; }
+    public required bool ExternallyOwned { get; init; }
 }

--- a/Inject.NET.SourceGenerator/Writers/ScopeWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/ScopeWriter.cs
@@ -171,15 +171,25 @@ internal static class ScopeWriter
         {
             // Wrap the base implementation with decorators
             var wrappedInvocation = constructNewObject;
-            
+
             foreach (var decorator in decoratorList)
             {
                 wrappedInvocation = WrapWithDecorator(rootServiceModelCollection, decorator, wrappedInvocation);
             }
-            
+
+            if (serviceModel.ExternallyOwned)
+            {
+                return wrappedInvocation;
+            }
+
             return $"Register<{serviceModel.ServiceType.GloballyQualified()}>({wrappedInvocation})";
         }
-        
+
+        if (serviceModel.ExternallyOwned)
+        {
+            return constructNewObject;
+        }
+
         return $"Register<{serviceModel.ServiceType.GloballyQualified()}>({constructNewObject})";
     }
     

--- a/Inject.NET.SourceGenerator/Writers/ServiceRegistrarWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/ServiceRegistrarWriter.cs
@@ -68,10 +68,15 @@ internal static class ServiceRegistrarWriter
         sourceCodeWriter.WriteLine($"ServiceType = typeof({serviceModel.ServiceType.GloballyQualified()}),");
         sourceCodeWriter.WriteLine($"ImplementationType = typeof({serviceModel.ImplementationType.GloballyQualified()}),");
         sourceCodeWriter.WriteLine($"Lifetime = Inject.NET.Enums.Lifetime.{serviceModel.Lifetime.ToString()},");
-                
+
         if(serviceModel.Key is not null)
         {
             sourceCodeWriter.WriteLine($"Key = \"{serviceModel.Key}\",");
+        }
+
+        if(serviceModel.ExternallyOwned)
+        {
+            sourceCodeWriter.WriteLine("ExternallyOwned = true,");
         }
                 
         sourceCodeWriter.WriteLine("Factory = (scope, type, key) =>");

--- a/Inject.NET.SourceGenerator/Writers/TenantScopeWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/TenantScopeWriter.cs
@@ -40,9 +40,14 @@ internal static class TenantScopeWriter
                 {
                     var fieldName = NameHelper.AsField(serviceModel);
                     sourceCodeWriter.WriteLine($"private {serviceModel.ServiceType.GloballyQualified()}? {fieldName};");
-                    
+
+                    var constructNewObject = ObjectConstructionHelper.ConstructNewObject(serviceProviderModel.Type, tenantServices.Services, serviceModel, Lifetime.Scoped);
+                    var invocation = serviceModel.ExternallyOwned
+                        ? constructNewObject
+                        : $"Register<{serviceModel.ServiceType.GloballyQualified()}>({constructNewObject})";
+
                     sourceCodeWriter.WriteLine(
-                        $"public {serviceModel.ServiceType.GloballyQualified()} {propertyName} => {fieldName} ??= Register<{serviceModel.ServiceType.GloballyQualified()}>({ObjectConstructionHelper.ConstructNewObject(serviceProviderModel.Type, tenantServices.Services, serviceModel, Lifetime.Scoped)});");
+                        $"public {serviceModel.ServiceType.GloballyQualified()} {propertyName} => {fieldName} ??= {invocation};");
                 }
             }
 

--- a/Inject.NET.SourceGenerator/Writers/TenantServiceRegistrarWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/TenantServiceRegistrarWriter.cs
@@ -78,6 +78,11 @@ internal static class TenantServiceRegistrarWriter
             sourceCodeWriter.WriteLine($"Key = \"{serviceModel.Key}\",");
         }
 
+        if (serviceModel.ExternallyOwned)
+        {
+            sourceCodeWriter.WriteLine("ExternallyOwned = true,");
+        }
+
         sourceCodeWriter.WriteLine("Factory = (scope, type, key) =>");
 
         if (serviceModel.IsOpenGeneric)

--- a/Inject.NET.Tests/ExternallyOwnedTests.cs
+++ b/Inject.NET.Tests/ExternallyOwnedTests.cs
@@ -1,0 +1,218 @@
+using Inject.NET.Attributes;
+using Inject.NET.Extensions;
+
+namespace Inject.NET.Tests;
+
+public partial class ExternallyOwnedTests
+{
+    [Test]
+    public async Task ExternallyOwned_Singleton_IsNotDisposed_WhenProviderIsDisposed()
+    {
+        DisposableSingleton instance;
+
+        var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        await using (var scope = serviceProvider.CreateScope())
+        {
+            instance = scope.GetRequiredService<DisposableSingleton>();
+            await Assert.That(instance.IsDisposed).IsFalse();
+        }
+
+        await serviceProvider.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+    }
+
+    [Test]
+    public async Task ExternallyOwned_Scoped_IsNotDisposed_WhenScopeIsDisposed()
+    {
+        DisposableScoped instance;
+
+        await using var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        var scope = serviceProvider.CreateScope();
+        instance = scope.GetRequiredService<DisposableScoped>();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+
+        await scope.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+    }
+
+    [Test]
+    public async Task ExternallyOwned_Transient_IsNotDisposed_WhenScopeIsDisposed()
+    {
+        DisposableTransient instance;
+
+        await using var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        var scope = serviceProvider.CreateScope();
+        instance = scope.GetRequiredService<DisposableTransient>();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+
+        await scope.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+    }
+
+    [Test]
+    public async Task NonExternallyOwned_Singleton_IsDisposed_WhenProviderIsDisposed()
+    {
+        ManagedDisposableSingleton instance;
+
+        var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        await using (var scope = serviceProvider.CreateScope())
+        {
+            instance = scope.GetRequiredService<ManagedDisposableSingleton>();
+            await Assert.That(instance.IsDisposed).IsFalse();
+        }
+
+        await serviceProvider.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsTrue();
+    }
+
+    [Test]
+    public async Task NonExternallyOwned_Scoped_IsDisposed_WhenScopeIsDisposed()
+    {
+        ManagedDisposableScoped instance;
+
+        await using var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        var scope = serviceProvider.CreateScope();
+        instance = scope.GetRequiredService<ManagedDisposableScoped>();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+
+        await scope.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsTrue();
+    }
+
+    [Test]
+    public async Task NonExternallyOwned_Transient_IsDisposed_WhenScopeIsDisposed()
+    {
+        ManagedDisposableTransient instance;
+
+        await using var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        var scope = serviceProvider.CreateScope();
+        instance = scope.GetRequiredService<ManagedDisposableTransient>();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+
+        await scope.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsTrue();
+    }
+
+    [Test]
+    public async Task ExternallyOwned_AsyncDisposable_Singleton_IsNotDisposed_WhenProviderIsDisposed()
+    {
+        AsyncDisposableSingleton instance;
+
+        var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        await using (var scope = serviceProvider.CreateScope())
+        {
+            instance = scope.GetRequiredService<AsyncDisposableSingleton>();
+            await Assert.That(instance.IsDisposed).IsFalse();
+        }
+
+        await serviceProvider.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsFalse();
+    }
+
+    [Test]
+    public async Task NonExternallyOwned_AsyncDisposable_Singleton_IsDisposed_WhenProviderIsDisposed()
+    {
+        ManagedAsyncDisposableSingleton instance;
+
+        var serviceProvider = await ExternallyOwnedServiceProvider.BuildAsync();
+
+        await using (var scope = serviceProvider.CreateScope())
+        {
+            instance = scope.GetRequiredService<ManagedAsyncDisposableSingleton>();
+            await Assert.That(instance.IsDisposed).IsFalse();
+        }
+
+        await serviceProvider.DisposeAsync();
+
+        await Assert.That(instance.IsDisposed).IsTrue();
+    }
+
+    // --- Service types ---
+
+    public class DisposableSingleton : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class DisposableScoped : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class DisposableTransient : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class AsyncDisposableSingleton : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public class ManagedDisposableSingleton : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class ManagedDisposableScoped : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class ManagedDisposableTransient : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class ManagedAsyncDisposableSingleton : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // --- Service Provider ---
+
+    [ServiceProvider]
+    [Singleton<DisposableSingleton>(ExternallyOwned = true)]
+    [Scoped<DisposableScoped>(ExternallyOwned = true)]
+    [Transient<DisposableTransient>(ExternallyOwned = true)]
+    [Singleton<AsyncDisposableSingleton>(ExternallyOwned = true)]
+    [Singleton<ManagedDisposableSingleton>]
+    [Scoped<ManagedDisposableScoped>]
+    [Transient<ManagedDisposableTransient>]
+    [Singleton<ManagedAsyncDisposableSingleton>]
+    public partial class ExternallyOwnedServiceProvider;
+}

--- a/Inject.NET/Attributes/DependencyInjectionAttribute.cs
+++ b/Inject.NET/Attributes/DependencyInjectionAttribute.cs
@@ -15,8 +15,14 @@ public abstract class DependencyInjectionAttribute : Attribute, IDependencyInjec
     }
 
     public abstract Lifetime Lifetime { get; }
-    
+
     public string? Key { get; set; }
+
+    /// <summary>
+    /// When set to true, the container will not dispose this service when the scope or provider is disposed.
+    /// Use this for services whose lifetime is managed externally (e.g., shared connections, pre-existing instances).
+    /// </summary>
+    public bool ExternallyOwned { get; set; }
 
     public Type ServiceType { get; }
     public Type ImplementationType { get; }

--- a/Inject.NET/Models/ServiceDescriptor.cs
+++ b/Inject.NET/Models/ServiceDescriptor.cs
@@ -9,5 +9,11 @@ public class ServiceDescriptor
     public required Type ImplementationType { get; init; }
     public required Lifetime Lifetime { get; init; }
     public string? Key { get; init; }
+
+    /// <summary>
+    /// When true, the container will not dispose this service when the scope or provider is disposed.
+    /// </summary>
+    public bool ExternallyOwned { get; init; }
+
     public required Func<IServiceScope, Type, string?, object> Factory { get; init; }
 }

--- a/Inject.NET/Services/ServiceScope.cs
+++ b/Inject.NET/Services/ServiceScope.cs
@@ -221,13 +221,13 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
 
         var obj = descriptor.Factory(originatingScope, serviceKey.Type, descriptor.Key);
 
-            
+
         if(descriptor.Lifetime != Lifetime.Transient)
         {
             (_cachedObjects ??= Pools.Objects.Get())[serviceKey] = obj;
         }
 
-        if(obj is IAsyncDisposable or IDisposable)
+        if(!descriptor.ExternallyOwned && obj is IAsyncDisposable or IDisposable)
         {
             (_forDisposal ??= Pools.DisposalTracker.Get()).Add(obj);
         }
@@ -292,8 +292,8 @@ public class ServiceScope<TSelf, TServiceProvider, TSingletonScope, TParentScope
             else
             {
                 item = serviceDescriptor.Factory(scope, serviceKey.Type, serviceDescriptor.Key);
-                
-                if(item is IAsyncDisposable or IDisposable)
+
+                if(!serviceDescriptor.ExternallyOwned && item is IAsyncDisposable or IDisposable)
                 {
                     (_forDisposal ??= Pools.DisposalTracker.Get()).Add(item);
                 }

--- a/Inject.NET/Services/SingletonScope.cs
+++ b/Inject.NET/Services/SingletonScope.cs
@@ -124,7 +124,10 @@ where TParentServiceScope : IServiceScope
             foreach (var descriptor in singletonDescriptors)
             {
                 var obj = descriptor.Factory(originScope, key.Type, descriptor.Key);
-                self.Register(obj);
+                if (!descriptor.ExternallyOwned)
+                {
+                    self.Register(obj);
+                }
                 results.Add(obj);
             }
 


### PR DESCRIPTION
## Summary
- Adds `ExternallyOwned` property to all DI attributes (`[Singleton]`, `[Scoped]`, `[Transient]`)
- When `ExternallyOwned = true`, the container will NOT dispose the service when the scope/provider is disposed
- Useful for shared resources like `HttpClient`, `IDbConnection`, or objects managed by other frameworks
- Updates both compile-time (source generator) and runtime (dictionary-based) resolution paths

## Usage
```csharp
[Singleton<HttpClient>(ExternallyOwned = true)]    // Will NOT be disposed by container
[Scoped<DbConnection>(ExternallyOwned = true)]     // Will NOT be disposed by container
[Singleton<MyService>]                              // Will be disposed by container (default)
```

## Test plan
- [x] 4 tests verifying externally owned services are NOT disposed (IDisposable + IAsyncDisposable, singleton + scoped + transient)
- [x] 4 regression tests verifying non-externally-owned services ARE still disposed
- [x] All 170 tests pass (162 existing + 8 new)
- [x] Source generator snapshot tests: 17/17 passing

Closes #16