### PR TITLE
feat: Support opt-in property injection via [Inject] attribute

### DIFF
--- a/Inject.NET.SourceGenerator/Helpers/PropertyInjectionHelper.cs
+++ b/Inject.NET.SourceGenerator/Helpers/PropertyInjectionHelper.cs
@@ -1,0 +1,181 @@
+using Inject.NET.SourceGenerator.Models;
+using Microsoft.CodeAnalysis;
+
+namespace Inject.NET.SourceGenerator.Helpers;
+
+/// <summary>
+/// Provides helper methods for generating property injection code.
+/// Property injection sets properties marked with [Inject] on service instances after construction,
+/// resolving their values from the container.
+/// </summary>
+internal static class PropertyInjectionHelper
+{
+    /// <summary>
+    /// Returns whether the service model has any inject properties.
+    /// </summary>
+    public static bool HasInjectProperties(ServiceModel serviceModel)
+    {
+        return serviceModel.InjectProperties.Length > 0;
+    }
+
+    /// <summary>
+    /// Returns whether the service model has any inject methods or inject properties.
+    /// </summary>
+    public static bool HasAnyPostConstructionInjection(ServiceModel serviceModel)
+    {
+        return MethodInjectionHelper.HasInjectMethods(serviceModel) || HasInjectProperties(serviceModel);
+    }
+
+    /// <summary>
+    /// Generates the property injection assignment code for a factory lambda context (ServiceRegistrar).
+    /// In this context, values are resolved from the 'scope' variable.
+    /// </summary>
+    /// <param name="serviceModel">The service model with inject properties.</param>
+    /// <param name="instanceVarName">The variable name holding the constructed instance.</param>
+    /// <returns>Lines of code to set inject properties, or empty if none.</returns>
+    public static IEnumerable<string> GenerateFactoryPropertyAssignments(ServiceModel serviceModel, string instanceVarName)
+    {
+        foreach (var property in serviceModel.InjectProperties)
+        {
+            var resolution = BuildFactoryPropertyResolution(property);
+            yield return $"{instanceVarName}.{property.PropertyName} = {resolution};";
+        }
+    }
+
+    /// <summary>
+    /// Generates the property injection assignment code for a scope/property context.
+    /// In this context, values are resolved using 'this' or 'Singletons' references.
+    /// </summary>
+    /// <param name="serviceProviderType">The service provider type for resolving dependencies.</param>
+    /// <param name="dependencies">All registered dependencies.</param>
+    /// <param name="serviceModel">The service model with inject properties.</param>
+    /// <param name="currentLifetime">Current service lifetime context.</param>
+    /// <param name="instanceVarName">The variable name holding the constructed instance.</param>
+    /// <returns>Lines of code to set inject properties.</returns>
+    public static IEnumerable<string> GenerateScopePropertyAssignments(
+        INamedTypeSymbol serviceProviderType,
+        IDictionary<ServiceModelCollection.ServiceKey, List<ServiceModel>> dependencies,
+        ServiceModel serviceModel,
+        Lifetime currentLifetime,
+        string instanceVarName)
+    {
+        foreach (var property in serviceModel.InjectProperties)
+        {
+            var resolution = BuildScopePropertyResolution(serviceProviderType, dependencies, serviceModel, currentLifetime, property);
+            yield return $"{instanceVarName}.{property.PropertyName} = {resolution};";
+        }
+    }
+
+    private static string BuildFactoryPropertyResolution(InjectProperty property)
+    {
+        // Handle Lazy<T> properties
+        if (property.IsLazy && property.LazyInnerType != null)
+        {
+            var innerType = property.LazyInnerType;
+            if (property.Key is null)
+            {
+                return $"new global::System.Lazy<{innerType.GloballyQualified()}>(() => scope.GetRequiredService<{innerType.GloballyQualified()}>())";
+            }
+            else
+            {
+                return $"new global::System.Lazy<{innerType.GloballyQualified()}>(() => scope.GetRequiredService<{innerType.GloballyQualified()}>(\"{property.Key}\"))";
+            }
+        }
+
+        // Handle Func<T> properties
+        if (property.IsFunc && property.FuncInnerType != null)
+        {
+            var innerType = property.FuncInnerType;
+            return $"new global::System.Func<{innerType.GloballyQualified()}>(() => scope.GetRequiredService<{innerType.GloballyQualified()}>())";
+        }
+
+        // Handle enumerable properties
+        if (property.IsEnumerable)
+        {
+            var elementType = property.PropertyType is INamedTypeSymbol { IsGenericType: true } genericType
+                ? genericType.TypeArguments[0]
+                : property.PropertyType;
+
+            var key = property.Key is null ? "null" : $"\"{property.Key}\"";
+            return $"[..scope.GetServices<{elementType.GloballyQualified()}>({key})]";
+        }
+
+        // Handle nullable (optional) properties
+        if (property.IsNullable)
+        {
+            return $"scope.GetOptionalService<{property.PropertyType.GloballyQualified()}>()";
+        }
+
+        // Handle required properties
+        return $"scope.GetRequiredService<{property.PropertyType.GloballyQualified()}>()";
+    }
+
+    private static string BuildScopePropertyResolution(
+        INamedTypeSymbol serviceProviderType,
+        IDictionary<ServiceModelCollection.ServiceKey, List<ServiceModel>> dependencies,
+        ServiceModel serviceModel,
+        Lifetime currentLifetime,
+        InjectProperty property)
+    {
+        // Handle Lazy<T> properties
+        if (property.IsLazy && property.LazyInnerType != null)
+        {
+            var innerType = property.LazyInnerType;
+            var innerServiceKey = new ServiceModelCollection.ServiceKey(innerType, property.Key);
+
+            if (dependencies.TryGetValue(innerServiceKey, out var lazyModels))
+            {
+                var lastModel = lazyModels[^1];
+                var innerResolution = TypeHelper.GetOrConstructType(serviceProviderType, dependencies, lastModel, currentLifetime);
+                return $"new global::System.Lazy<{innerType.GloballyQualified()}>(() => {innerResolution})";
+            }
+
+            return $"new global::System.Lazy<{innerType.GloballyQualified()}>(() => this.GetRequiredService<{innerType.GloballyQualified()}>())";
+        }
+
+        // Handle Func<T> properties
+        if (property.IsFunc && property.FuncInnerType != null)
+        {
+            var innerType = property.FuncInnerType;
+            var innerServiceKey = new ServiceModelCollection.ServiceKey(innerType, property.Key);
+
+            if (dependencies.TryGetValue(innerServiceKey, out var funcModels))
+            {
+                var lastModel = funcModels[^1];
+                var resolution = TypeHelper.GetOrConstructType(serviceProviderType, dependencies, lastModel, lastModel.Lifetime);
+                return $"new global::System.Func<{innerType.GloballyQualified()}>(() => {resolution})";
+            }
+
+            return $"new global::System.Func<{innerType.GloballyQualified()}>(() => this.GetRequiredService<{innerType.GloballyQualified()}>())";
+        }
+
+        // Handle enumerable properties
+        if (property.IsEnumerable)
+        {
+            var elementType = property.PropertyType is INamedTypeSymbol { IsGenericType: true } genericType
+                ? genericType.TypeArguments[0]
+                : property.PropertyType;
+
+            var key = property.Key is null ? "null" : $"\"{property.Key}\"";
+            return $"[..this.GetServices<{elementType.GloballyQualified()}>({key})]";
+        }
+
+        // For non-special types, try to resolve from known dependencies
+        var serviceKey = new ServiceModelCollection.ServiceKey(property.PropertyType, property.Key);
+
+        if (dependencies.TryGetValue(serviceKey, out var models))
+        {
+            var lastModel = models[^1];
+            return TypeHelper.GetOrConstructType(serviceProviderType, dependencies, lastModel, currentLifetime);
+        }
+
+        // Nullable (optional) properties
+        if (property.IsNullable)
+        {
+            return $"this.GetOptionalService<{property.PropertyType.GloballyQualified()}>()";
+        }
+
+        // Required properties
+        return $"this.GetRequiredService<{property.PropertyType.GloballyQualified()}>()";
+    }
+}

--- a/Inject.NET.SourceGenerator/Models/InjectProperty.cs
+++ b/Inject.NET.SourceGenerator/Models/InjectProperty.cs
@@ -1,0 +1,56 @@
+using Microsoft.CodeAnalysis;
+
+namespace Inject.NET.SourceGenerator.Models;
+
+/// <summary>
+/// Represents a property marked with [Inject] on a service implementation type.
+/// The property will be set after construction with a service resolved from the container.
+/// </summary>
+public record InjectProperty
+{
+    /// <summary>
+    /// The name of the property to set.
+    /// </summary>
+    public required string PropertyName { get; init; }
+
+    /// <summary>
+    /// The type of the property.
+    /// </summary>
+    public required ITypeSymbol PropertyType { get; init; }
+
+    /// <summary>
+    /// Whether the property type is nullable (optional).
+    /// Nullable properties use GetOptionalService; non-nullable use GetRequiredService.
+    /// </summary>
+    public required bool IsNullable { get; init; }
+
+    /// <summary>
+    /// Whether the property type is Lazy&lt;T&gt;.
+    /// </summary>
+    public bool IsLazy { get; init; }
+
+    /// <summary>
+    /// The inner type of Lazy&lt;T&gt; if IsLazy is true.
+    /// </summary>
+    public ITypeSymbol? LazyInnerType { get; init; }
+
+    /// <summary>
+    /// Whether the property type is Func&lt;T&gt;.
+    /// </summary>
+    public bool IsFunc { get; init; }
+
+    /// <summary>
+    /// The inner type of Func&lt;T&gt; if IsFunc is true.
+    /// </summary>
+    public ITypeSymbol? FuncInnerType { get; init; }
+
+    /// <summary>
+    /// Whether the property type is an enumerable (IEnumerable&lt;T&gt; or similar).
+    /// </summary>
+    public bool IsEnumerable { get; init; }
+
+    /// <summary>
+    /// The optional service key from [ServiceKey] attribute, if present.
+    /// </summary>
+    public string? Key { get; init; }
+}

--- a/Inject.NET.SourceGenerator/Models/ServiceModel.cs
+++ b/Inject.NET.SourceGenerator/Models/ServiceModel.cs
@@ -20,6 +20,8 @@ public record ServiceModel
 
     public required InjectMethod[] InjectMethods { get; init; }
 
+    public required InjectProperty[] InjectProperties { get; init; }
+
     public required int Index { get; init; }
     
     public ServiceModelCollection.ServiceKey ServiceKey => new(ServiceType, Key);

--- a/Inject.NET.SourceGenerator/Models/ServiceModelBuilder.cs
+++ b/Inject.NET.SourceGenerator/Models/ServiceModelBuilder.cs
@@ -16,6 +16,7 @@ public record ServiceModelBuilder
 
     public required Parameter[] Parameters { get; init; }
     public required InjectMethod[] InjectMethods { get; init; }
+    public required InjectProperty[] InjectProperties { get; init; }
     public required string? TenantName { get; init; }
     public required bool ExternallyOwned { get; init; }
 }

--- a/Inject.NET.SourceGenerator/Writers/ServiceRegistrarWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/ServiceRegistrarWriter.cs
@@ -117,8 +117,8 @@ internal static class ServiceRegistrarWriter
             finalInvocation = baseInvocation;
         }
 
-        // Check if method injection is needed
-        if (MethodInjectionHelper.HasInjectMethods(serviceModel))
+        // Check if post-construction injection (methods or properties) is needed
+        if (PropertyInjectionHelper.HasAnyPostConstructionInjection(serviceModel))
         {
             sourceCodeWriter.WriteLine("Factory = (scope, type, key) =>");
             sourceCodeWriter.WriteLine("{");
@@ -127,6 +127,11 @@ internal static class ServiceRegistrarWriter
             foreach (var injectCall in MethodInjectionHelper.GenerateFactoryInjectCalls(serviceModel, "__instance"))
             {
                 sourceCodeWriter.WriteLine(injectCall);
+            }
+
+            foreach (var propertyAssignment in PropertyInjectionHelper.GenerateFactoryPropertyAssignments(serviceModel, "__instance"))
+            {
+                sourceCodeWriter.WriteLine(propertyAssignment);
             }
 
             sourceCodeWriter.WriteLine("return __instance;");

--- a/Inject.NET.SourceGenerator/Writers/TenantServiceRegistrarWriter.cs
+++ b/Inject.NET.SourceGenerator/Writers/TenantServiceRegistrarWriter.cs
@@ -104,8 +104,8 @@ internal static class TenantServiceRegistrarWriter
             baseInvocation = $"new {lastTypeInDictionary.ImplementationType.GloballyQualified()}({string.Join(", ", BuildParameters(serviceModel))})";
         }
 
-        // Check if method injection is needed
-        if (MethodInjectionHelper.HasInjectMethods(serviceModel))
+        // Check if post-construction injection (methods or properties) is needed
+        if (PropertyInjectionHelper.HasAnyPostConstructionInjection(serviceModel))
         {
             sourceCodeWriter.WriteLine("Factory = (scope, type, key) =>");
             sourceCodeWriter.WriteLine("{");
@@ -114,6 +114,11 @@ internal static class TenantServiceRegistrarWriter
             foreach (var injectCall in MethodInjectionHelper.GenerateFactoryInjectCalls(serviceModel, "__instance"))
             {
                 sourceCodeWriter.WriteLine(injectCall);
+            }
+
+            foreach (var propertyAssignment in PropertyInjectionHelper.GenerateFactoryPropertyAssignments(serviceModel, "__instance"))
+            {
+                sourceCodeWriter.WriteLine(propertyAssignment);
             }
 
             sourceCodeWriter.WriteLine("return __instance;");

--- a/Inject.NET.Tests/PropertyInjectionTests.cs
+++ b/Inject.NET.Tests/PropertyInjectionTests.cs
@@ -1,0 +1,231 @@
+using Inject.NET.Attributes;
+using Inject.NET.Extensions;
+
+namespace Inject.NET.Tests;
+
+public partial class PropertyInjectionTests
+{
+    [Test]
+    public async Task InjectProperty_IsSetAfterConstruction()
+    {
+        await using var serviceProvider = await PropertyInjectionServiceProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.GetRequiredService<IServiceWithInjectProperty>();
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(((ServiceWithInjectProperty)service).InjectedDependency).IsNotNull();
+    }
+
+    [Test]
+    public async Task InjectProperty_NullableProperty_IsOptional_WhenNotRegistered()
+    {
+        await using var serviceProvider = await NullablePropertyInjectionServiceProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.GetRequiredService<ServiceWithNullableInjectProperty>();
+
+        await Assert.That(service).IsNotNull();
+        // The nullable property should be null since UnregisteredDependency is not registered
+        await Assert.That(service.OptionalDependency).IsNull();
+        // The required property should still be set
+        await Assert.That(service.RequiredDependency).IsNotNull();
+    }
+
+    [Test]
+    public async Task InjectProperty_MultipleProperties_AllAreSet()
+    {
+        await using var serviceProvider = await MultiplePropertyInjectionServiceProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.GetRequiredService<ServiceWithMultipleInjectProperties>();
+
+        await Assert.That(service.FirstDependency).IsNotNull();
+        await Assert.That(service.SecondDependency).IsNotNull();
+    }
+
+    [Test]
+    public async Task InjectProperty_WorksWithTransientLifetime()
+    {
+        await using var serviceProvider = await TransientPropertyInjectionServiceProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var service1 = scope.GetRequiredService<TransientServiceWithInjectProperty>();
+        var service2 = scope.GetRequiredService<TransientServiceWithInjectProperty>();
+
+        await Assert.That(service1.InjectedDependency).IsNotNull();
+        await Assert.That(service2.InjectedDependency).IsNotNull();
+        await Assert.That(service1.Id).IsNotEqualTo(service2.Id);
+    }
+
+    [Test]
+    public async Task InjectProperty_WorksWithScopedLifetime()
+    {
+        await using var serviceProvider = await ScopedPropertyInjectionServiceProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.GetRequiredService<ScopedServiceWithInjectProperty>();
+
+        await Assert.That(service.InjectedDependency).IsNotNull();
+    }
+
+    [Test]
+    public async Task InjectProperty_CombinedWithConstructorInjection()
+    {
+        await using var serviceProvider = await CombinedInjectionServiceProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.GetRequiredService<ServiceWithConstructorAndPropertyInjection>();
+
+        // Constructor-injected dependency
+        await Assert.That(service.ConstructorDependency).IsNotNull();
+        // Property-injected dependency
+        await Assert.That(service.PropertyDependency).IsNotNull();
+    }
+
+    [Test]
+    public async Task InjectProperty_CombinedWithMethodInjection()
+    {
+        await using var serviceProvider = await CombinedMethodAndPropertyInjectionServiceProvider.BuildAsync();
+
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.GetRequiredService<ServiceWithMethodAndPropertyInjection>();
+
+        // Method-injected
+        await Assert.That(service.WasInitialized).IsTrue();
+        await Assert.That(service.MethodDependency).IsNotNull();
+        // Property-injected
+        await Assert.That(service.PropertyDependency).IsNotNull();
+    }
+
+    // --- Service definitions ---
+
+    public interface IServiceWithInjectProperty;
+
+    public class PropertyDependency
+    {
+        public string Id { get; } = Guid.NewGuid().ToString("N");
+    }
+
+    public class AnotherPropertyDependency
+    {
+        public string Id { get; } = Guid.NewGuid().ToString("N");
+    }
+
+    public class UnregisteredDependency;
+
+    public class ServiceWithInjectProperty : IServiceWithInjectProperty
+    {
+        [Inject]
+        public PropertyDependency InjectedDependency { get; set; } = null!;
+    }
+
+    public class ServiceWithNullableInjectProperty
+    {
+        [Inject]
+        public PropertyDependency RequiredDependency { get; set; } = null!;
+
+        [Inject]
+        public UnregisteredDependency? OptionalDependency { get; set; }
+    }
+
+    public class ServiceWithMultipleInjectProperties
+    {
+        [Inject]
+        public PropertyDependency FirstDependency { get; set; } = null!;
+
+        [Inject]
+        public AnotherPropertyDependency SecondDependency { get; set; } = null!;
+    }
+
+    public class TransientServiceWithInjectProperty
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+
+        [Inject]
+        public PropertyDependency InjectedDependency { get; set; } = null!;
+    }
+
+    public class ScopedServiceWithInjectProperty
+    {
+        [Inject]
+        public PropertyDependency InjectedDependency { get; set; } = null!;
+    }
+
+    public class ServiceWithConstructorAndPropertyInjection
+    {
+        public PropertyDependency ConstructorDependency { get; }
+
+        [Inject]
+        public AnotherPropertyDependency PropertyDependency { get; set; } = null!;
+
+        public ServiceWithConstructorAndPropertyInjection(PropertyDependency constructorDependency)
+        {
+            ConstructorDependency = constructorDependency;
+        }
+    }
+
+    public class ServiceWithMethodAndPropertyInjection
+    {
+        public bool WasInitialized { get; private set; }
+        public PropertyDependency? MethodDependency { get; private set; }
+
+        [Inject]
+        public AnotherPropertyDependency PropertyDependency { get; set; } = null!;
+
+        [Inject]
+        public void Initialize(PropertyDependency dependency)
+        {
+            WasInitialized = true;
+            MethodDependency = dependency;
+        }
+    }
+
+    // --- Service providers ---
+
+    [ServiceProvider]
+    [Scoped<IServiceWithInjectProperty, ServiceWithInjectProperty>]
+    [Scoped<PropertyDependency>]
+    public partial class PropertyInjectionServiceProvider;
+
+    [ServiceProvider]
+    [Scoped<ServiceWithNullableInjectProperty>]
+    [Scoped<PropertyDependency>]
+    // Note: UnregisteredDependency is NOT registered, so the nullable property should be null
+    public partial class NullablePropertyInjectionServiceProvider;
+
+    [ServiceProvider]
+    [Scoped<ServiceWithMultipleInjectProperties>]
+    [Scoped<PropertyDependency>]
+    [Scoped<AnotherPropertyDependency>]
+    public partial class MultiplePropertyInjectionServiceProvider;
+
+    [ServiceProvider]
+    [Transient<TransientServiceWithInjectProperty>]
+    [Transient<PropertyDependency>]
+    public partial class TransientPropertyInjectionServiceProvider;
+
+    [ServiceProvider]
+    [Scoped<ScopedServiceWithInjectProperty>]
+    [Scoped<PropertyDependency>]
+    public partial class ScopedPropertyInjectionServiceProvider;
+
+    [ServiceProvider]
+    [Scoped<ServiceWithConstructorAndPropertyInjection>]
+    [Scoped<PropertyDependency>]
+    [Scoped<AnotherPropertyDependency>]
+    public partial class CombinedInjectionServiceProvider;
+
+    [ServiceProvider]
+    [Scoped<ServiceWithMethodAndPropertyInjection>]
+    [Scoped<PropertyDependency>]
+    [Scoped<AnotherPropertyDependency>]
+    public partial class CombinedMethodAndPropertyInjectionServiceProvider;
+}

--- a/Inject.NET/Attributes/InjectAttribute.cs
+++ b/Inject.NET/Attributes/InjectAttribute.cs
@@ -1,21 +1,32 @@
 namespace Inject.NET.Attributes;
 
 /// <summary>
-/// Marks a method for method injection. Methods marked with this attribute will be called
+/// Marks a method or property for injection. Methods marked with this attribute will be called
 /// after the service instance is constructed, with their parameters resolved from the container.
+/// Properties marked with this attribute will be set after construction with services resolved from the container.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Multiple methods can be marked with [Inject] on a single class. They are called in declaration order.
+/// Multiple methods and properties can be marked with [Inject] on a single class. Methods are called in declaration order.
 /// </para>
 /// <para>
 /// Async methods (returning Task or ValueTask) are supported and will be awaited during service creation.
+/// </para>
+/// <para>
+/// Nullable properties are treated as optional and will be set to null if the service is not registered.
+/// Non-nullable properties are required and will throw if the service is not registered.
 /// </para>
 /// </remarks>
 /// <example>
 /// <code>
 /// public class MyService : IMyService
 /// {
+///     [Inject]
+///     public ILogger Logger { get; set; }
+///
+///     [Inject]
+///     public ICache? OptionalCache { get; set; } // nullable = optional
+///
 ///     [Inject]
 ///     public void Initialize(ILogger logger, ICache cache)
 ///     {
@@ -24,5 +35,5 @@ namespace Inject.NET.Attributes;
 /// }
 /// </code>
 /// </example>
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
 public sealed class InjectAttribute : Attribute;


### PR DESCRIPTION
## Summary
- Extends the existing `[Inject]` attribute to support properties (in addition to methods)
- Source generator detects `[Inject]`-annotated properties and generates post-construction assignments
- Works across all service lifetimes (Singleton, Scoped, Transient) and tenant scopes

Closes #13

## Changes
- `InjectAttribute.cs`: Updated `AttributeTargets` to include `Property`
- `InjectProperty.cs` (new): Model for injectable properties
- `PropertyInjectionHelper.cs` (new): Helper for generating property assignment code
- Updated `ScopeWriter`, `ServiceRegistrarWriter`, `TenantScopeWriter`, `TenantServiceRegistrarWriter` to support property injection
- Updated `ServiceModel`, `ServiceModelBuilder`, `DependencyDictionary` to collect inject properties
- 7 new tests covering property injection scenarios

## Test plan
- [x] 209 tests passing (7 new property injection tests + 202 existing)
- [x] Zero build errors
- [x] Property injection works with Singleton, Scoped, and Transient lifetimes