### PR TITLE
feat: Add parameter overrides at resolve time

### DIFF
--- a/Inject.NET.Tests/ParameterOverrideTests.cs
+++ b/Inject.NET.Tests/ParameterOverrideTests.cs
@@ -1,0 +1,198 @@
+using Inject.NET.Attributes;
+using Inject.NET.Extensions;
+using Inject.NET.Models;
+
+namespace Inject.NET.Tests;
+
+public partial class ParameterOverrideTests
+{
+    [Test]
+    public async Task TypedParameter_OverridesConstructorParameterByType()
+    {
+        await using var serviceProvider = await ParameterOverrideServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.Resolve<ServiceWithConnectionString>(
+            new TypedParameter<string>("Server=custom"));
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(service.ConnectionString).IsEqualTo("Server=custom");
+    }
+
+    [Test]
+    public async Task NamedParameter_OverridesConstructorParameterByName()
+    {
+        await using var serviceProvider = await ParameterOverrideServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.Resolve<ServiceWithConnectionString>(
+            new NamedParameter("connectionString", "Server=named"));
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(service.ConnectionString).IsEqualTo("Server=named");
+    }
+
+    [Test]
+    public async Task NonOverriddenParameters_ResolvedFromContainer()
+    {
+        await using var serviceProvider = await ParameterOverrideServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.Resolve<ServiceWithMixedDependencies>(
+            new NamedParameter("connectionString", "Server=mixed"));
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(service.ConnectionString).IsEqualTo("Server=mixed");
+        // The ILogger dependency should have been resolved from the container
+        await Assert.That(service.Logger).IsNotNull();
+        await Assert.That(service.Logger).IsTypeOf<ConsoleLogger>();
+    }
+
+    [Test]
+    public async Task MultipleParameters_AllApplied()
+    {
+        await using var serviceProvider = await ParameterOverrideServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.Resolve<ServiceWithMultipleParams>(
+            new NamedParameter("name", "TestService"),
+            new TypedParameter<int>(42));
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(service.Name).IsEqualTo("TestService");
+        await Assert.That(service.Value).IsEqualTo(42);
+        // The ILogger dependency should have been resolved from the container
+        await Assert.That(service.Logger).IsNotNull();
+    }
+
+    [Test]
+    public async Task TypedParameter_OverridesIntParameter()
+    {
+        await using var serviceProvider = await ParameterOverrideServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.Resolve<ServiceWithIntParam>(
+            new TypedParameter<int>(99));
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(service.Count).IsEqualTo(99);
+    }
+
+    [Test]
+    public async Task NamedParameter_DistinguishesBetweenSameTypeParameters()
+    {
+        await using var serviceProvider = await ParameterOverrideServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.Resolve<ServiceWithTwoStrings>(
+            new NamedParameter("first", "Hello"),
+            new NamedParameter("second", "World"));
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(service.First).IsEqualTo("Hello");
+        await Assert.That(service.Second).IsEqualTo("World");
+    }
+
+    [Test]
+    public async Task Resolve_WithNoParameters_ResolvesAllFromContainer()
+    {
+        await using var serviceProvider = await ParameterOverrideServiceProvider.BuildAsync();
+        await using var scope = serviceProvider.CreateScope();
+
+        var service = scope.Resolve<ServiceWithOnlyContainerDeps>();
+
+        await Assert.That(service).IsNotNull();
+        await Assert.That(service.Logger).IsNotNull();
+        await Assert.That(service.Logger).IsTypeOf<ConsoleLogger>();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Service Provider Definition
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [ServiceProvider]
+    [Singleton<ILogger, ConsoleLogger>]
+    public partial class ParameterOverrideServiceProvider;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test Services
+    // ═══════════════════════════════════════════════════════════════════════
+
+    public interface ILogger
+    {
+        string Name { get; }
+    }
+
+    public class ConsoleLogger : ILogger
+    {
+        public string Name => "ConsoleLogger";
+    }
+
+    public class ServiceWithConnectionString
+    {
+        public string ConnectionString { get; }
+
+        public ServiceWithConnectionString(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }
+    }
+
+    public class ServiceWithMixedDependencies
+    {
+        public string ConnectionString { get; }
+        public ILogger Logger { get; }
+
+        public ServiceWithMixedDependencies(ILogger logger, string connectionString)
+        {
+            Logger = logger;
+            ConnectionString = connectionString;
+        }
+    }
+
+    public class ServiceWithMultipleParams
+    {
+        public string Name { get; }
+        public int Value { get; }
+        public ILogger Logger { get; }
+
+        public ServiceWithMultipleParams(ILogger logger, string name, int value)
+        {
+            Logger = logger;
+            Name = name;
+            Value = value;
+        }
+    }
+
+    public class ServiceWithIntParam
+    {
+        public int Count { get; }
+
+        public ServiceWithIntParam(int count)
+        {
+            Count = count;
+        }
+    }
+
+    public class ServiceWithTwoStrings
+    {
+        public string First { get; }
+        public string Second { get; }
+
+        public ServiceWithTwoStrings(string first, string second)
+        {
+            First = first;
+            Second = second;
+        }
+    }
+
+    public class ServiceWithOnlyContainerDeps
+    {
+        public ILogger Logger { get; }
+
+        public ServiceWithOnlyContainerDeps(ILogger logger)
+        {
+            Logger = logger;
+        }
+    }
+}

--- a/Inject.NET/Extensions/ParameterResolutionExtensions.cs
+++ b/Inject.NET/Extensions/ParameterResolutionExtensions.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+using Inject.NET.Interfaces;
+using Inject.NET.Models;
+
+namespace Inject.NET.Extensions;
+
+/// <summary>
+/// Provides extension methods for resolving services with parameter overrides.
+/// Allows passing runtime values for constructor parameters that would normally
+/// be resolved from the container.
+/// </summary>
+public static class ParameterResolutionExtensions
+{
+    /// <summary>
+    /// Resolves a service of type T, overriding specific constructor parameters
+    /// with the provided values. Non-overridden parameters are resolved from
+    /// the container as usual.
+    /// </summary>
+    /// <typeparam name="T">The type of service to resolve</typeparam>
+    /// <param name="scope">The service scope to resolve dependencies from</param>
+    /// <param name="parameters">The parameter overrides to apply</param>
+    /// <returns>A new instance of T with the specified parameter overrides applied</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when type T has no public constructors.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// var repo = scope.Resolve&lt;Repository&gt;(new NamedParameter("connectionString", "Server=..."));
+    /// var handler = scope.Resolve&lt;Handler&gt;(new TypedParameter&lt;string&gt;("customValue"));
+    /// var service = scope.Resolve&lt;MyService&gt;(
+    ///     new TypedParameter&lt;int&gt;(42),
+    ///     new NamedParameter("name", "test")
+    /// );
+    /// </code>
+    /// </example>
+    public static T Resolve<T>(this IServiceScope scope, params Parameter[] parameters) where T : class
+    {
+        return (T)ResolveInternal(scope, typeof(T), parameters);
+    }
+
+    /// <summary>
+    /// Resolves a service of the specified type, overriding specific constructor parameters
+    /// with the provided values. Non-overridden parameters are resolved from
+    /// the container as usual.
+    /// </summary>
+    /// <param name="scope">The service scope to resolve dependencies from</param>
+    /// <param name="serviceType">The type of service to resolve</param>
+    /// <param name="parameters">The parameter overrides to apply</param>
+    /// <returns>A new instance of the specified type with the specified parameter overrides applied</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the type has no public constructors.
+    /// </exception>
+    public static object Resolve(this IServiceScope scope, Type serviceType, params Parameter[] parameters)
+    {
+        return ResolveInternal(scope, serviceType, parameters);
+    }
+
+    private static object ResolveInternal(IServiceScope scope, Type type, Parameter[] parameters)
+    {
+        // Find best constructor - prefer constructor with most parameters (same logic as ServiceFactory<T>)
+        var constructor = type
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+        if (constructor == null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot create instance of type '{type.FullName}'. " +
+                $"The type has no public constructors. " +
+                $"Ensure the type has at least one public constructor for dependency injection.");
+        }
+
+        var constructorParams = constructor.GetParameters();
+        var arguments = new object?[constructorParams.Length];
+
+        for (int i = 0; i < constructorParams.Length; i++)
+        {
+            var param = constructorParams[i];
+            var paramType = param.ParameterType;
+            var paramName = param.Name ?? string.Empty;
+
+            // Check if any parameter override matches
+            if (TryMatchParameter(parameters, paramType, paramName, out var overrideValue))
+            {
+                arguments[i] = overrideValue;
+                continue;
+            }
+
+            // No override matched - resolve from the container
+            var serviceKey = new ServiceKey(paramType);
+
+            bool isNullableReference = !paramType.IsValueType;
+            bool isNullableValueType = Nullable.GetUnderlyingType(paramType) != null;
+            bool hasDefaultValue = param.HasDefaultValue;
+            bool isOptional = isNullableReference || isNullableValueType || hasDefaultValue;
+
+            var resolved = scope.GetService(serviceKey);
+
+            if (resolved != null)
+            {
+                arguments[i] = resolved;
+            }
+            else if (hasDefaultValue)
+            {
+                arguments[i] = param.DefaultValue;
+            }
+            else if (isOptional)
+            {
+                arguments[i] = null;
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Cannot resolve parameter '{paramName}' of type '{paramType.FullName}' " +
+                    $"for service '{type.FullName}'. " +
+                    $"No parameter override was provided and the type is not registered in the container.");
+            }
+        }
+
+        return constructor.Invoke(arguments);
+    }
+
+    private static bool TryMatchParameter(Parameter[] parameters, Type paramType, string paramName, out object? value)
+    {
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (parameters[i].TryMatch(paramType, paramName, out value))
+            {
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+}

--- a/Inject.NET/Models/Parameter.cs
+++ b/Inject.NET/Models/Parameter.cs
@@ -1,0 +1,86 @@
+namespace Inject.NET.Models;
+
+/// <summary>
+/// Base class for parameter overrides used when resolving services.
+/// Allows providing runtime values for constructor parameters that would
+/// normally be resolved from the container.
+/// </summary>
+public abstract class Parameter
+{
+    /// <summary>
+    /// Attempts to match this parameter override against a constructor parameter.
+    /// </summary>
+    /// <param name="parameterType">The type of the constructor parameter</param>
+    /// <param name="parameterName">The name of the constructor parameter</param>
+    /// <param name="value">The override value if matched</param>
+    /// <returns>True if this parameter override matches the constructor parameter</returns>
+    public abstract bool TryMatch(Type parameterType, string parameterName, out object? value);
+}
+
+/// <summary>
+/// A parameter override that matches constructor parameters by type.
+/// When resolving a service, any constructor parameter of type T will
+/// receive the specified value instead of being resolved from the container.
+/// </summary>
+/// <typeparam name="T">The type of the parameter to override</typeparam>
+public class TypedParameter<T> : Parameter
+{
+    private readonly T _value;
+
+    /// <summary>
+    /// Creates a new typed parameter override.
+    /// </summary>
+    /// <param name="value">The value to use for constructor parameters of type T</param>
+    public TypedParameter(T value)
+    {
+        _value = value;
+    }
+
+    /// <inheritdoc />
+    public override bool TryMatch(Type parameterType, string parameterName, out object? value)
+    {
+        if (parameterType == typeof(T))
+        {
+            value = _value;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+}
+
+/// <summary>
+/// A parameter override that matches constructor parameters by name.
+/// When resolving a service, any constructor parameter with the specified
+/// name will receive the provided value instead of being resolved from the container.
+/// </summary>
+public class NamedParameter : Parameter
+{
+    private readonly string _name;
+    private readonly object? _value;
+
+    /// <summary>
+    /// Creates a new named parameter override.
+    /// </summary>
+    /// <param name="name">The constructor parameter name to match</param>
+    /// <param name="value">The value to use for the matched parameter</param>
+    public NamedParameter(string name, object? value)
+    {
+        _name = name;
+        _value = value;
+    }
+
+    /// <inheritdoc />
+    public override bool TryMatch(Type parameterType, string parameterName, out object? value)
+    {
+        if (string.Equals(_name, parameterName, StringComparison.Ordinal))
+        {
+            value = _value;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TypedParameter<T>` and `NamedParameter` for overriding constructor parameters at resolve time
- `Resolve<T>(params Parameter[])` extension method on `IServiceScope`
- Uses reflection-based construction with override matching; non-overridden params resolve from container
- Purely additive - no existing files modified

Closes #24

## Changes
- `Parameter.cs` (new): `Parameter` base, `TypedParameter<T>`, `NamedParameter` types
- `ParameterResolutionExtensions.cs` (new): `Resolve<T>()` and `Resolve(Type)` extensions
- 7 new tests covering typed params, named params, mixed scenarios, and container fallback

## Test plan
- [x] 209 tests passing (7 new parameter override tests + 202 existing)
- [x] Zero build errors
- [x] TypedParameter, NamedParameter, and mixed overrides all work correctly